### PR TITLE
Update GUI code to work with KSP 1.1 and Unity 5

### DIFF
--- a/KSPPluginFramework/MonoBehaviourWindow.cs
+++ b/KSPPluginFramework/MonoBehaviourWindow.cs
@@ -90,7 +90,11 @@ namespace KSPPluginFramework
             GameEvents.onGUIMissionControlSpawn.Add(HideUI);
             GameEvents.onGUIMissionControlDespawn.Add(HideUI);
             GameEvents.onGUIKSPediaSpawn.Add(HideUI);
-            GameEvents.onGUIKSPediaSpawn.Add(ShowUI);
+            GameEvents.onGUIKSPediaDespawn.Add(ShowUI);
+            GameEvents.onGUIAstronautComplexSpawn.Add(HideUI);
+            GameEvents.onGUIAstronautComplexDespawn.Add(ShowUI);
+            GameEvents.onGUIRnDComplexSpawn.Add(HideUI);
+            GameEvents.onGUIRnDComplexDespawn.Add(ShowUI);
         }
 
         internal bool bHideUI = false;

--- a/KSPPluginFramework/MonoBehaviourWindow.cs
+++ b/KSPPluginFramework/MonoBehaviourWindow.cs
@@ -81,7 +81,29 @@ namespace KSPPluginFramework
             //just some debugging stuff here
             LogFormatted_DebugOnly("New MBWindow Awakened");
 
-            //base.Awake();
+            base.Awake();
+
+            GameEvents.onShowUI.Add(ShowUI);
+            GameEvents.onHideUI.Add(HideUI);
+            GameEvents.onGUIAdministrationFacilitySpawn.Add(HideUI);
+            GameEvents.onGUIAdministrationFacilityDespawn.Add(ShowUI);
+            GameEvents.onGUIMissionControlSpawn.Add(HideUI);
+            GameEvents.onGUIMissionControlDespawn.Add(HideUI);
+            GameEvents.onGUIKSPediaSpawn.Add(HideUI);
+            GameEvents.onGUIKSPediaSpawn.Add(ShowUI);
+        }
+
+        internal bool bHideUI = false;
+        public void ShowUI()
+        {
+            LogFormatted_DebugOnly("Setting HideUI = False");
+            bHideUI = false;
+        }
+
+        public void HideUI()
+        {
+            LogFormatted_DebugOnly("Setting HideUI = True");
+            bHideUI = true;
         }
 
         /// <summary>
@@ -124,6 +146,13 @@ namespace KSPPluginFramework
         /// </summary>
         internal RectOffset ClampToScreenOffset = new RectOffset(0, 0, 0, 0);
 
+        internal override void OnGUIEvery()
+        {
+            if (bHideUI)
+                return;
+            DrawGUI(); // Your current on postDrawQueue code            
+        }
+
         private Boolean _Visible;
         /// <summary>
         /// Whether the Window is visible or not. Changing this value will add/remove the window from the RenderingManager.PostDrawQueue
@@ -135,18 +164,12 @@ namespace KSPPluginFramework
             {
                 if (_Visible != value)
                 {
-                    if (value)
-                    {
-                        LogFormatted_DebugOnly("Adding Window to PostDrawQueue-{0}", WindowID);
-                        RenderingManager.AddToPostDrawQueue(5, this.DrawGUI);
-                    }
-                    else
-                    {
-                        LogFormatted_DebugOnly("Removing Window from PostDrawQueue", WindowID);
-                        RenderingManager.RemoveFromPostDrawQueue(5, this.DrawGUI);
-                    }
+                    //raise event if theres one registered
+                    if (onWindowVisibleChanged != null)
+                        onWindowVisibleChanged(this, value);
                 }
                 _Visible = value;
+                
             }
         }
 
@@ -156,6 +179,9 @@ namespace KSPPluginFramework
         /// </summary>
         private void DrawGUI()
         {
+            if (!_Visible)
+                return;
+            
             //this sets the skin on each draw loop
             GUI.skin = SkinsLibrary.CurrentSkin;
 
@@ -198,6 +224,7 @@ namespace KSPPluginFramework
             DrawWindow(id);
 
             DrawWindowPost(id);
+
 
             //Set the Tooltip variable based on whats in this window
             if (TooltipsEnabled)
@@ -339,10 +366,10 @@ namespace KSPPluginFramework
                 TooltipShown = false;
             }
 
-			//if we've moved to a diffn tooltip then reset the counter
-			if (strToolTipText != strLastTooltipText) fltTooltipTime = 0f;
-			
-			//make sure the last text is correct
+            //if we've moved to a diffn tooltip then reset the counter
+            if (strToolTipText != strLastTooltipText) fltTooltipTime = 0f;
+            
+            //make sure the last text is correct
             strLastTooltipText = strToolTipText;
         }
 


### PR DESCRIPTION
This changes the GUI handling to work properly under KSP 1.1 and Unity 5.  So far it seems solid.

One additional change is required inside of MonoBehaviourWindowPlus but that doesn't seem to be a part of this project.  In that class it is important that the OnGUIEvery() method call the base.

```
 internal override void OnGUIEvery()
 {
        base.OnGUIEvery();
        ddlManager.CloseOnOutsideClicks();
 }
```
